### PR TITLE
wearOS networking not-null error

### DIFF
--- a/wear/src/main/java/com/example/saloris/NetWorking.kt
+++ b/wear/src/main/java/com/example/saloris/NetWorking.kt
@@ -59,7 +59,7 @@ class NetWorking : WearableListenerService(),
     var steal : String = ""
 
 
-    override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         activityContext = this
         try {
             Wearable.getDataClient(activityContext!!).addListener(this)
@@ -71,7 +71,7 @@ class NetWorking : WearableListenerService(),
         }
 
         if(mobileDeviceConnected){
-            var S = intent.getStringExtra("heartRate")
+            var S = intent!!.getStringExtra("heartRate")
             if (S!!.isNotEmpty()) {
                 val nodeId: String = messageEvent?.sourceNodeId!!
                 // Set the data of the message to be the bytes of the Uri.


### PR DESCRIPTION
워치 앱을 종료했다가 다시 실행할 때 종료되는 오류 해결
원인 : networking에서 Parameter 중에 Notnull 인데 null이 넘어 와서