### PR TITLE
wear stop networking service with stop button

### DIFF
--- a/wear/src/main/java/com/example/saloris/ExerciseFragment.kt
+++ b/wear/src/main/java/com/example/saloris/ExerciseFragment.kt
@@ -153,6 +153,8 @@ class ExerciseFragment : Fragment(), AmbientModeSupport.AmbientCallbackProvider,
         binding.pauseResumeButton.setOnClickListener {
             // App could take a perceptible amount of time to transition between states; put button into
             // an intermediary "disabled" state to provide UI feedback.
+            Log.d("stop service","stop")
+            activity?.stopService(serviceIt)
             it.isEnabled = false
             pauseResumeExercise()
         }


### PR DESCRIPTION
종료 버튼을 눌렀을 때 networking 서비스를 종료시켜서 networking service가 종료 후에도 백그라운드에서 돌아가는 문제(워치 앱이 종료되어도 진동이 울린다) 해결